### PR TITLE
Tolerant `readUint32`

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,6 +392,7 @@ function readUint32 (buffer) {
 	if ( ! Number.isInteger(parsedInt) ) {
 		throw new TypeError('Value read as integer ' + parsedInt + ' is not an integer');
 	}
+	parsedInt = (parsedInt>>>0);
 	if ( parsedInt < MIN_UNSIGNED_INT32 || parsedInt > MAX_UNSIGNED_INT32 ) {
 		throw new RangeError('Read integer ' + parsedInt + ' is outside the unsigned 32-bit range');
 	}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "getopts": "*"
+    "getopts": "*",
+    "mocha": "^10.2.0"
   },
   "contributors": [
     {
@@ -47,6 +48,7 @@
   "author": "Mark Abrahams <mark@abrahams.co.nz>",
   "license": "MIT",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint . ./**/*.js"
+    "lint": "./node_modules/.bin/eslint . ./**/*.js",
+    "test": "./node_modules/mocha/bin/mocha.js"
   }
 }

--- a/test/varbinds.js
+++ b/test/varbinds.js
@@ -1,22 +1,20 @@
-/* eslint-disable no-unused-expressions */
-
-var ber    = require ('asn1-ber').Ber;
-var assert = require('assert');
-var snmp   = require('../');
+const ber    = require ('asn1-ber').Ber;
+const assert = require('assert');
+const snmp   = require('../');
 
 describe('parseInt()', function() {
 	describe('given a negative integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(-3);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a negative integer', function() {
 			assert.equal(-3, snmp.ObjectParser.readInt32(reader));
 		});
-	}),
+	});
 	describe('given a positive integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(3245689);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
 			assert.equal(3245689, snmp.ObjectParser.readInt32(reader));
 		});
@@ -25,27 +23,27 @@ describe('parseInt()', function() {
 
 describe('parseUint()', function() {
 	describe('given a positive integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(3242425);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
 			assert.equal(3242425, snmp.ObjectParser.readUint32(reader));
 		});
 	});
 	describe('given a negative integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(-3);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
 			assert.equal(4294967293, snmp.ObjectParser.readUint32(reader));
 		});
 	});
 	describe('given a large integer', function() {
-		var writer = new ber.Writer();
-		writer.writeInt(4294967293);
-		var reader = new ber.Reader(writer.buffer);
+		const writer = new ber.Writer();
+		writer.writeInt(4294967294);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(4294967293, snmp.ObjectParser.readUint32(reader));
+			assert.equal(4294967294, snmp.ObjectParser.readUint32(reader));
 		});
 	});
 });

--- a/test/varbinds.js
+++ b/test/varbinds.js
@@ -10,7 +10,7 @@ describe('parseInt()', function() {
 		writer.writeInt(-3);
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a negative integer', function() {
-			assert.equal(-3, snmp.ObjectParser.readInt(reader));
+			assert.equal(-3, snmp.ObjectParser.readInt32(reader));
 		});
 	}),
 	describe('given a positive integer', function() {
@@ -18,7 +18,7 @@ describe('parseInt()', function() {
 		writer.writeInt(3245689);
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(3245689, snmp.ObjectParser.readInt(reader));
+			assert.equal(3245689, snmp.ObjectParser.readInt32(reader));
 		});
 	});
 });
@@ -29,15 +29,23 @@ describe('parseUint()', function() {
 		writer.writeInt(3242425);
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(3242425, snmp.ObjectParser.readUint(reader));
+			assert.equal(3242425, snmp.ObjectParser.readUint32(reader));
 		});
-	}),
+	});
 	describe('given a negative integer', function() {
 		var writer = new ber.Writer();
 		writer.writeInt(-3);
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(253, snmp.ObjectParser.readUint(reader));
+			assert.equal(4294967293, snmp.ObjectParser.readUint32(reader));
+		});
+	});
+	describe('given a large integer', function() {
+		var writer = new ber.Writer();
+		writer.writeInt(4294967293);
+		var reader = new ber.Reader(writer.buffer);
+		it('returns a positive integer', function() {
+			assert.equal(4294967293, snmp.ObjectParser.readUint32(reader));
 		});
 	});
 });


### PR DESCRIPTION
 - **improve**: add test library and script
 - **improve**: be more tolerant with `readUint32` for missing leading byte required by ASN.1 BER